### PR TITLE
feat: add launch80 make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 HOST_PORT ?= 80
 
-.PHONY: help install dev dev-web build start prisma-generate prisma-migrate db-seed docker-build docker-up docker-down docker-logs launch check-api docker-toggle docker-publish-latest docker-release
+.PHONY: help install dev dev-web build start prisma-generate prisma-migrate db-seed docker-build docker-up docker-down docker-logs launch launch80 check-api docker-toggle docker-publish-latest docker-release
 
 .DEFAULT_GOAL := help
 
@@ -77,7 +77,40 @@ launch: ## One-shot dev: installs deps (unless SKIP_INSTALL=1), prepares DB, run
 	server_pid=$$!; \
 	npm run -s dev; \
 	kill $$server_pid 2>/dev/null || true; \
-		wait $$server_pid 2>/dev/null || true
+                wait $$server_pid 2>/dev/null || true
+
+launch80: ## One-shot dev on web port 80: installs deps (unless SKIP_INSTALL=1), prepares DB, runs web+server
+	@if [ ! -f .env ]; then \
+	echo ".env not found. Copying from .env.example"; \
+	cp .env.example .env; \
+	fi
+	@if [ -z "$$SKIP_INSTALL" ]; then \
+	echo "Ensuring root dependencies..."; \
+	npm install; \
+	echo "Ensuring web dependencies..."; \
+	npm --prefix web install; \
+	else \
+	echo "Skipping dependency install (SKIP_INSTALL=1)"; \
+	fi
+	@echo "Generating Prisma client..." && npm run -s prisma:generate
+	@echo "Applying Prisma migrations (dev)..." && npm run -s prisma:migrate
+	@echo "Seeding defaults (idempotent)..." && npm run -s db:seed
+	@echo "Detecting LAN IPs..."
+	@IPS=$$(ifconfig 2>/dev/null | awk '/inet / && $$2 != "127.0.0.1" {print $$2}'); \
+	if [ -n "$$IPS" ]; then \
+	  echo "Access on LAN:"; \
+	  for ip in $$IPS; do \
+	    echo "  - $$ip (Display: http://$$ip:80  API: http://$$ip:3000)"; \
+	  done; \
+	else \
+	  echo "No non-loopback IPv4 detected. You can still use http://localhost and http://localhost:3000"; \
+	fi
+	@echo "Starting web dev server (80) and API (3000)..."
+	@npm run -s dev:web -- --port 80 & \
+	server_pid=$$!; \
+	npm run -s dev; \
+	kill $$server_pid 2>/dev/null || true; \
+	wait $$server_pid 2>/dev/null || true
 
 check-api: ## Quick API checks on 3000 and 5173 (proxy)
 	@echo "Checking API on :3000 (direct)" && \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Factory reset
 - Run `make help` to list available commands.
 - `make launch` — one-shot dev: installs dependencies (unless `SKIP_INSTALL=1`), prepares DB (generate/migrate/seed), then starts web (5173) + server (3000).
   - Prints detected LAN IPs so you can open `http://<ip>:5173/` from other devices.
+- `make launch80` — same as `launch` but serves the web app on port 80 instead of 5173.
 - `make install` — install dependencies
 - `make prisma-generate` — generate Prisma client
 - `make prisma-migrate` — run migrations (dev)


### PR DESCRIPTION
## Summary
- add `launch80` make target to run web server on port 80 alongside API on 3000
- document `launch80` target in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9fd3a60648322bd5debec3a859d89