### PR TITLE
feat(web): persist screen sync settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -96,16 +96,34 @@ function Display() {
   // Screen sync params read once (allow adjustments via UI which update URL)
   const initialScreenIndex = useMemo(() => {
     const sp = new URLSearchParams(window.location.search)
-    const v = Number(sp.get('screenIndex') || '')
-    return Number.isFinite(v) && v > 0 ? v : 1
+    let v = Number(sp.get('screenIndex') || '')
+    if (!Number.isFinite(v) || v <= 0) {
+      const ls = Number(localStorage.getItem('screenIndex') || '')
+      v = Number.isFinite(ls) && ls > 0 ? ls : 1
+    }
+    return v
   }, [])
   const initialScreenCount = useMemo(() => {
     const sp = new URLSearchParams(window.location.search)
-    const v = Number(sp.get('screenCount') || '')
-    return Number.isFinite(v) && v > 0 ? v : 1
+    let v = Number(sp.get('screenCount') || '')
+    if (!Number.isFinite(v) || v <= 0) {
+      const ls = Number(localStorage.getItem('screenCount') || '')
+      v = Number.isFinite(ls) && ls > 0 ? ls : 1
+    }
+    return v
   }, [])
   const [screenIndexParam, setScreenIndexParam] = useState<number>(initialScreenIndex)
   const [screenCountParam, setScreenCountParam] = useState<number>(initialScreenCount)
+
+  useEffect(() => {
+    if (screenIndexParam > 1) localStorage.setItem('screenIndex', String(screenIndexParam))
+    else localStorage.removeItem('screenIndex')
+  }, [screenIndexParam])
+
+  useEffect(() => {
+    if (screenCountParam > 1) localStorage.setItem('screenCount', String(screenCountParam))
+    else localStorage.removeItem('screenCount')
+  }, [screenCountParam])
 
   useEffect(() => {
     const onFullscreenChange = () => {


### PR DESCRIPTION
## Summary
- preserve screen sync values between reloads using `localStorage`
- sync local storage whenever screen index/count change

## Testing
- `npm test`
- `npm --prefix web test`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9fe781c2483229f1ba12b00ae5dcf