### PR TITLE
Allow any host in Vite config

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   server: {
     host: true,
     port: 5173,
+    allowedHosts: 'all',
     proxy: {
       '/api': 'http://localhost:3000',
       '/socket.io': {


### PR DESCRIPTION
## Summary
- allow Vite dev server to accept requests from any host by setting `server.allowedHosts` to `'all'`

## Testing
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68b467cd4be48322b65deaafd500205a