### PR TITLE
Ensure cocktails alternate across two columns

### DIFF
--- a/web/src/display/hooks/useSlides.ts
+++ b/web/src/display/hooks/useSlides.ts
@@ -83,14 +83,15 @@ export default function useSlides({
     if (hasCocktails && allowCocktails) {
       const sorted = (cocktails || []).filter((c:any)=>c && c.active!==false).slice().sort((a:any,b:any)=> String(a.name).localeCompare(String(b.name)))
       const perCol = Math.max(1, effDrinksItemsPerCol)
-      const colCount = Math.max(1, columns)
+      const colCount = Math.max(2, columns)
       const perPage = perCol * colCount
       for (let i=0; i<sorted.length; i+=perPage) {
         const chunk = sorted.slice(i, i+perPage)
-        const columnsData: any[][] = []
-        for (let c=0;c<colCount;c++) {
-          columnsData.push(chunk.slice(c*perCol, (c+1)*perCol))
-        }
+        const columnsData: any[][] = Array.from({ length: colCount }, () => [])
+        chunk.forEach((cocktail:any, idx:number) => {
+          const targetCol = idx % colCount
+          columnsData[targetCol].push(cocktail)
+        })
         s.push({ type:'cocktails', data: { columns: columnsData } })
       }
     }


### PR DESCRIPTION
## Summary
- enforce two-column layout for cocktail slides
- alternate cocktails between columns instead of filling one column at a time

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692213820eb08322b32799633d90c37c)